### PR TITLE
Fix module name to correct path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleCloudPlatform/grpc-gcp-go
+module github.com/GoogleCloudPlatform/grpc-gcp-tools
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/grpc-gcp-tools
 
 go 1.13
 
-require google.golang.org/grpc v1.25.1 // indirect
+require google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Fix module name to correct path.

I think maybe copied from `github.com/GoogleCloudPlatform/grpc-gcp-go`, but this repository is `grpc-gcp-tools`.
Just fix it and run `go mod tidy`.