### PR TITLE
Remove reference to deleted LoadBalancerDelegate field

### DIFF
--- a/dp_check/dp_check.go
+++ b/dp_check/dp_check.go
@@ -109,9 +109,6 @@ func getBackendAddrsFromGrpclb(lbAddr string) ([]string, error) {
 	if initResp == nil {
 		return nil, fmt.Errorf("gRPC reply from balancer did not include initial response", err)
 	}
-	if initResp.LoadBalancerDelegate != "" {
-		return nil, fmt.Errorf("grpc balancer delegation is not supported")
-	}
 	// Just wait for the first non-empty server list
 	for {
 		reply, err = stream.Recv()


### PR DESCRIPTION
This field was deleted from the protobuf in https://github.com/grpc/grpc-proto/pull/78