### PR TITLE
Update dp_check

### DIFF
--- a/dp_check/dp_check.go
+++ b/dp_check/dp_check.go
@@ -113,7 +113,7 @@ const (
 
 	trafficDirectorPort             = "443"
 	userAgentName                   = "dp-check"
-	userAgentVersion                = "1.5-dev"
+	userAgentVersion                = "1.5"
 	clientFeatureNoOverprovisioning = "envoy.lb.does_not_support_overprovisioning"
 	ipv6CapableMetadataName         = "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"
 	zoneURL                         = "http://metadata.google.internal/computeMetadata/v1/instance/zone"


### PR DESCRIPTION
- Update default Traffic Director hostname
- Fix assumption of at most 2 second priority clusters
- Fix user-agent to not appear like a grpc-go client