### PR TITLE
Kokoro setup: minimum config to start a build

### DIFF
--- a/build/kokoro/build.sh
+++ b/build/kokoro/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+gcloud config set project stanleycheung-gke2-dev
+
+gcloud config list
+
+kubectl config view

--- a/build/kokoro/continuous.cfg
+++ b/build/kokoro/continuous.cfg
@@ -1,0 +1,1 @@
+build_file: "grpc-gcp-tools/build/kokoro/kokoro_build.sh"

--- a/build/kokoro/kokoro_build.sh
+++ b/build/kokoro/kokoro_build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+cd "${KOKORO_ARTIFACTS_DIR}/github/grpc-gcp-tools/build/kokoro"
+./build.sh


### PR DESCRIPTION
This PR adds some Kokoro config files to hopefully allow us to start and run a minimal Kokoro build. This requires cl/473863051 to be merged first.