### PR TITLE
Observability Testing: pass docker image tag to test runner

### DIFF
--- a/build/kokoro/build.sh
+++ b/build/kokoro/build.sh
@@ -92,9 +92,9 @@ build_java () {
     ${GRPC_JAVA_REPO_PATH} ${REPOS_BASE_DIR}/grpc-java
   cd ${REPOS_BASE_DIR}/grpc-java
   LANG='java' docker_image_tag
-  gcloud container images describe ${TAG_NAME} && echo "Image already built, skipping..." || ( \
+  check_docker_image || ( \
     ./buildscripts/observability-test/build_docker.sh && \
-    docker push ${TAG_NAME})
+    docker push ${TAG_NAME} )
   export OBSERVABILITY_TEST_IMAGE_JAVA=${TAG_NAME}
 }
 
@@ -104,9 +104,9 @@ build_go () {
     ${GRPC_GO_REPO_PATH} ${REPOS_BASE_DIR}/grpc-go
   cd ${REPOS_BASE_DIR}/grpc-go
   LANG='go' docker_image_tag
-  gcloud container images describe ${TAG_NAME} && echo "Image already built, skipping..." || ( \
+  check_docker_image || ( \
     ./interop/observability/build_docker.sh && \
-    docker push ${TAG_NAME})
+    docker push ${TAG_NAME} )
   export OBSERVABILITY_TEST_IMAGE_GO=${TAG_NAME}
 }
 
@@ -116,10 +116,14 @@ build_cpp () {
     ${GRPC_GRPC_REPO_PATH} ${REPOS_BASE_DIR}/grpc
   cd ${REPOS_BASE_DIR}/grpc
   LANG='cpp' docker_image_tag
-  gcloud container images describe ${TAG_NAME} && echo "Image already built, skipping..." || ( \
+  check_docker_image || ( \
     ./tools/dockerfile/observability-test/cpp/build_docker.sh && \
-    docker push ${TAG_NAME})
+    docker push ${TAG_NAME} )
   export OBSERVABILITY_TEST_IMAGE_CPP=${TAG_NAME}
+}
+
+check_docker_image() {
+  gcloud container images describe ${TAG_NAME} && echo "Image already built, skipping..."
 }
 
 docker_image_tag () {

--- a/observability/test/run_o11y_tests.py
+++ b/observability/test/run_o11y_tests.py
@@ -69,7 +69,6 @@ OBSERVABILITY_LOG_NAME = 'microservices.googleapis.com%2Fobservability%2Fgrpc'
 CONFIG_ENV_VAR_NAME = 'GRPC_GCP_OBSERVABILITY_CONFIG'
 CONFIG_FILE_ENV_VAR_NAME = 'GRPC_GCP_OBSERVABILITY_CONFIG_FILE'
 CONFIG_FILE_LOCAL_DIR = '/tmp'
-IMAGE_TAG = '1.53.0-dev'
 SUPPORTED_METRICS = [
     'custom.googleapis.com/opencensus/grpc.io/client/started_rpcs',
     'custom.googleapis.com/opencensus/grpc.io/server/started_rpcs',
@@ -111,7 +110,7 @@ def parse_args() -> argparse.Namespace:
 class CommonUtil:
     @staticmethod
     def get_image_name(lang: SupportedLang, job_mode: JobMode) -> str:
-        return 'gcr.io/%s/grpc-observability/testing/%s-%s:%s' % (PROJECT, job_mode, lang, IMAGE_TAG)
+        return str(os.environ.get('OBSERVABILITY_TEST_IMAGE_%s' % str(lang).upper()))
 
 class TestRunner:
     args: argparse.Namespace


### PR DESCRIPTION
- Now the docker image for each language will be tagged with the commit hash instead of a fixed constant
- Remove the need for that constant (a TODO)
- If the docker image is already built on gcr.io, don't rebuild, just re-use the same tag.