### PR TITLE
Observability Testing: add script to run tests locally

### DIFF
--- a/build/kokoro/build.sh
+++ b/build/kokoro/build.sh
@@ -88,7 +88,10 @@ export REPOS_BASE_DIR=${KOKORO_ARTIFACTS_DIR}/github
 
 docker_image_tag () {
   SHORT_HASH=`git rev-parse --short HEAD`
-  export TAG_NAME=gcr.io/${PROJECT}/grpc-observability/testing/${JOB_MODE}-${LANG}:${SHORT_HASH}
+  IMAGE_NAME=gcr.io/${PROJECT}/grpc-observability/testing/${JOB_MODE}-${LANG}
+  # TODO(stanleycheung): use a more descriptive name than TAG_NAME, need to change all repos
+  export TAG_NAME=${IMAGE_NAME}:${SHORT_HASH}
+  IMAGE_TAG_LATEST=${IMAGE_NAME}:latest
 }
 
 check_docker_image() {
@@ -100,7 +103,11 @@ prepare_docker_image() {
   git clone --single-branch --branch ${GIT_CLONE_BRANCH} ${GIT_CLONE_PATH} ${REPOS_BASE_DIR}/${REPO_NAME}
   cd ${REPOS_BASE_DIR}/${REPO_NAME}
   docker_image_tag
-  check_docker_image || ( $BUILD_DOCKER_FUNC && docker push ${TAG_NAME} )
+  check_docker_image || ( \
+    $BUILD_DOCKER_FUNC && \
+    docker tag ${TAG_NAME} ${IMAGE_TAG_LATEST} && \
+    docker push ${TAG_NAME} && \
+    docker push ${IMAGE_TAG_LATEST} )
   export $DOCKER_IMAGE_ENV_VAR_NAME=${TAG_NAME}
 }
 

--- a/build/kokoro/requirements-dev.txt
+++ b/build/kokoro/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 mypy~=0.991
+docker~=6.0.1

--- a/observability/test/run_o11y_tests_local.py
+++ b/observability/test/run_o11y_tests_local.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright 2023 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run gRPC Observability interop test locally"""
+
+import argparse
+import docker # type: ignore
+import logging
+import os
+import subprocess
+import sys
+from test_utils import (
+    ObservabilityTestCase
+)
+
+SPONGE_LOGS_DIR = '/tmp/observability_test_log' # a directory in your local environment for logs
+DOCKER_IMAGE_NAME = 'gcr.io/microsvcs-testing/grpc-observability/testing/integration-%s:latest'
+
+argp = argparse.ArgumentParser(description='Run Observability integration tests in local env')
+argp.add_argument('--server_lang', required=True, type=str,
+                  help='Server language: java | go | cpp')
+argp.add_argument('--client_lang', required=True, type=str,
+                  help='Client language: java | go | cpp')
+argp.add_argument('--test_case', required=True, type=str,
+                  help='Test case to run: check test_utils.py')
+argp.add_argument('--docker_image_go', default=DOCKER_IMAGE_NAME % 'go', type=str,
+                  help='docker image tag for Go interop client/server')
+argp.add_argument('--docker_image_java', default=DOCKER_IMAGE_NAME % 'java', type=str,
+                  help='docker image tag for Java interop client/server')
+argp.add_argument('--docker_image_cpp', default=DOCKER_IMAGE_NAME % 'cpp', type=str,
+                  help='docker image tag for C++ interop client/server')
+args = argp.parse_args()
+
+docker_client = docker.from_env()
+
+logger = logging.getLogger(__name__)
+console_handler = logging.StreamHandler()
+formatter = logging.Formatter(fmt='%(asctime)s: %(levelname)-8s %(message)s')
+console_handler.setFormatter(formatter)
+logger.handlers = []
+logger.addHandler(console_handler)
+logger.setLevel(logging.DEBUG)
+
+def prepare_docker_image(lang):
+    args_dict = vars(args)
+    image_name = args_dict['docker_image_%s' % lang]
+    images = docker_client.images.list(name=image_name)
+    if len(images) == 0:
+        logger.warning("Docker image '%s' does not exist locally. Trying to docker pull ..." % image_name)
+        try:
+            if not docker_client.images.pull(repository=image_name):
+                raise Exception('No image found')
+        except:
+            logger.error("Still could not find docker image '%s'. Exiting...'" % image_name)
+            sys.exit(1)
+    logger.info("Using local docker image '%s'" % image_name)
+    os.environ['OBSERVABILITY_TEST_IMAGE_%s' % lang.upper()] = image_name
+
+def main():
+    os.makedirs(SPONGE_LOGS_DIR, exist_ok=True)
+    prepare_docker_image(args.server_lang)
+    prepare_docker_image(args.client_lang)
+    if args.test_case == 'all':
+        for test_case in ObservabilityTestCase:
+            run_test_case(test_case)
+    else:
+        run_test_case(args.test_case)
+
+def run_test_case(test_case):
+    os.environ['RESOURCE_TYPE_ASSERTION_OVERRIDE'] = 'global'
+    os.environ['CUSTOM_DOCKER_RUN_AUTH'] = \
+        '-v %s/.config/gcloud:/root/.config/gcloud' % os.environ.get('HOME')
+    os.environ['KOKORO_ARTIFACTS_DIR'] = SPONGE_LOGS_DIR
+    proc = subprocess.Popen(
+        [sys.executable, os.path.join(os.path.dirname(__file__), 'run_o11y_tests.py'),
+         '--server_lang', args.server_lang,
+         '--client_lang', args.client_lang,
+         '--job_mode', 'integration',
+         '--test_case', test_case,
+         '--port', '14286'])
+    proc.wait()
+
+# Main
+if __name__ == "__main__":
+    main()

--- a/observability/test/run_o11y_tests_local.py
+++ b/observability/test/run_o11y_tests_local.py
@@ -28,12 +28,12 @@ SPONGE_LOGS_DIR = '/tmp/observability_test_log' # a directory in your local envi
 DOCKER_IMAGE_NAME = 'gcr.io/microsvcs-testing/grpc-observability/testing/integration-%s:latest'
 
 argp = argparse.ArgumentParser(description='Run Observability integration tests in local env')
-argp.add_argument('--server_lang', required=True, type=str,
-                  help='Server language: java | go | cpp')
-argp.add_argument('--client_lang', required=True, type=str,
-                  help='Client language: java | go | cpp')
+argp.add_argument('--server_lang', required=True, type=str, choices=['java', 'go', 'cpp'],
+                  help='Server language')
+argp.add_argument('--client_lang', required=True, type=str, choices=['java', 'go', 'cpp'],
+                  help='Client language')
 argp.add_argument('--test_case', required=True, type=str,
-                  help='Test case to run: check test_utils.py')
+                  help='Test case to run: see test_utils.py')
 argp.add_argument('--docker_image_go', default=DOCKER_IMAGE_NAME % 'go', type=str,
                   help='docker image tag for Go interop client/server')
 argp.add_argument('--docker_image_java', default=DOCKER_IMAGE_NAME % 'java', type=str,


### PR DESCRIPTION
- Added a script `run_o11y_tests_local.py` to allow someone to run the Observability interop tests from a local environment, as long as the corresponding docker images are available locally.
- For this to work, each Kokoro job, in addition to pushing a tag `<image_name>:<current github commit hash>`, we should also push another tag `<image_name>:latest` so that we have an anchor to pull a default image.
- For the observability binary to work inside the docker image locally, we may need to inject the `-v $HOME/.config/gcloud:/root/.config/gcloud` auth credentials into the `docker run` command.