### PR TITLE
partition local logs by user

### DIFF
--- a/observability/test/run_o11y_tests_local.py
+++ b/observability/test/run_o11y_tests_local.py
@@ -24,7 +24,8 @@ from test_utils import (
     ObservabilityTestCase
 )
 
-SPONGE_LOGS_DIR = '/tmp/observability_test_log' # a directory in your local environment for logs
+# a directory in your local environment for logs
+SPONGE_LOGS_DIR = '/tmp/observability_test_log_%s' % os.environ.get('USER', 'user')
 DOCKER_IMAGE_NAME = 'gcr.io/microsvcs-testing/grpc-observability/testing/integration-%s:latest'
 
 argp = argparse.ArgumentParser(description='Run Observability integration tests in local env')


### PR DESCRIPTION
After trial with these local testing steps, the local log output directory is sort of a weak point - whoever runs the script first created the `/tmp/observability_test_log` directory and another user doesn't have access.

So let's partition this by `${USER}`.