### PR TITLE
Observability testing: add test case test_trace_diff_setting_endpoints

### DIFF
--- a/observability/test/test_utils.py
+++ b/observability/test/test_utils.py
@@ -40,6 +40,7 @@ class ObservabilityTestCase(str, Enum):
     TEST_CONFIGS_NO_CONFIG = 'test_configs_no_config'
     TEST_CONFIGS_INVALID_CONFIG = 'test_configs_invalid_config'
     TEST_CONFIGS_CUSTOM_LABELS = 'test_configs_custom_labels'
+    TEST_TRACE_DIFF_SETTING_ENDPOINTS = 'test_trace_diff_setting_endpoints'
     TEST_METRICS_BASIC = 'test_metrics_basic'
     TEST_METRICS_LATENCY = 'test_metrics_latency'
     TEST_METRICS_MESSAGE_BYTES = 'test_metrics_message_bytes'


### PR DESCRIPTION
Added a new test case `test_trace_diff_setting_endpoints` to test various combinations where client and server has different `sampling_rate` config values.


All 3 languages passed this new test case.